### PR TITLE
iOS darkmode tweak for DateAndTimePicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react": "~16.9.0",
     "react-dom": "^16.12.0",
     "react-native": "^0.61.5",
-    "react-native-appearance": "^0.3.2",
+    "react-native-appearance": "~0.3.1",
     "react-native-calendars": "^1.257.0",
     "react-native-clean-project": "^3.3.0",
     "react-native-dotenv": "^0.2.0",

--- a/src/layouts/Home-SubComponents/NewPickup-SubComponents/LocationComponents/DateAndTimePicker.js
+++ b/src/layouts/Home-SubComponents/NewPickup-SubComponents/LocationComponents/DateAndTimePicker.js
@@ -4,8 +4,8 @@ import DateTimePickerModal from "react-native-modal-datetime-picker";
 import { Appearance, useColorScheme } from 'react-native-appearance';
 
 const DateAndTimePicker = props => {
-  // Checking the dark mode of the phone, and if enabled, override it for iOS
-  const colorScheme = Appearance.getColorScheme();
+  // Checking the dark mode setting of the OS
+  const colorScheme = useColorScheme();
 
   // Display modes for Android (date/time)
   const [mode, setMode] = useState('date');
@@ -84,6 +84,11 @@ const DateAndTimePicker = props => {
           mode="datetime"
           onConfirm={handleIoSConfirm}
           onCancel={hideDatePicker}
+          style={{
+            backgroundColor: colorScheme === 'dark' 
+              ? 'grey'
+              : 'white'
+          }}
         />
       )}
 


### PR DESCRIPTION
-DateAndTimePicker would not be visible on my iPhone, because it was set to "dark mode".
-Added a conditional styling based on dark mode setting, could be cleaner but not sure how to reference the header/footer css.